### PR TITLE
Idempotently link config files & backup existing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,26 +28,24 @@ def app?(name)
 end
 
 def link_file(original_filename, symlink_filename)
-  original_path = File.expand_path original_filename
-  symlink_path = File.expand_path symlink_filename
-  if File.exists? symlink_path
+  original_path = File.expand_path(original_filename)
+  symlink_path = File.expand_path(symlink_filename)
+  if File.exists?(symlink_path)
     # Symlink already configured properly. Leave it alone.
     return if File.symlink?(symlink_path) and File.readlink(symlink_path) == original_path
     # Never move user's files without creating backups first
-    backing_up = true
     number = 1
-    while backing_up do
+    loop do
       backup_path = "#{symlink_path}.bak"
       if number > 1
         backup_path = "#{backup_path}#{number}"
       end
-      if File.exists? backup_path
-        puts "already seen file #{backup_path}"
+      if File.exists?(backup_path)
         number += 1
         next
       end
       mv symlink_path, backup_path, :verbose => true
-      backing_up = false
+      break
     end
   end
   ln_s original_path, symlink_path, :verbose => true


### PR DESCRIPTION
We never want to blast away someone's existing config files. This will
move any existing file to `[file].bak`. That includes:
- .vim directory
- .tmux.conf
- .vimrc

The .vimrc.local behavior just remains the same since we only copy, not
symlink.

@eventualbuddha 
