### PR TITLE
fix GitGutterToggle mapping in vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -55,7 +55,7 @@ nmap <leader>t :CommandT<CR>
 nmap <leader>T :CommandTFlush<CR>:CommandT<CR>
 nmap <leader>] :TagbarToggle<CR>
 nmap <leader><space> :call whitespace#strip_trailing()<CR>
-nmap <leader>g :ToggleGitGutter<CR>
+nmap <leader>g :GitGutterToggle<CR>
 nmap <leader>c <Plug>Kwbd
 map <silent> <leader>V :source ~/.vimrc<CR>:filetype detect<CR>:exe ":echo 'vimrc reloaded'"<CR>
 


### PR DESCRIPTION
Looks like the function name was changed in this commit: https://github.com/airblade/vim-gitgutter/commit/177365691bbb5fe191b2c9e52c3be2cda3372965
