### PR TITLE
Remove `brew update` from install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ namespace :install do
   desc 'Update or Install Brew'
   task :brew do
     step 'Homebrew'
-    unless system('which brew > /dev/null && brew update || ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"')
+    unless system('which brew > /dev/null || ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"')
       raise "Homebrew must be installed before continuing."
     end
   end


### PR DESCRIPTION
`brew` is often broken on people's systems if it's been installed for a while.
Installing maximum-awesome is _not_ the right way to find about that.

@strongriley @eventualbuddha 

It's back! This should fix all the confusion discussed in #32 
