### PR TITLE
Give submodule URLs consistency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,84 +1,84 @@
 [submodule "vim/bundle/nerdtree"]
 	path = vim/bundle/nerdtree
-	url = git://github.com/scrooloose/nerdtree.git
+	url = https://github.com/scrooloose/nerdtree.git
 [submodule "vim/bundle/ack"]
 	path = vim/bundle/ack
-	url = git://github.com/mileszs/ack.vim.git
+	url = https://github.com/mileszs/ack.vim.git
 [submodule "vim/bundle/cucumber"]
 	path = vim/bundle/cucumber
-	url = git://github.com/tpope/vim-cucumber.git
+	url = https://github.com/tpope/vim-cucumber.git
 [submodule "vim/bundle/endwise"]
 	path = vim/bundle/endwise
-	url = git://github.com/tpope/vim-endwise.git
+	url = https://github.com/tpope/vim-endwise.git
 [submodule "vim/bundle/fugitive"]
 	path = vim/bundle/fugitive
-	url = git://github.com/tpope/vim-fugitive
+	url = https://github.com/tpope/vim-fugitive
 [submodule "vim/bundle/indentobject"]
 	path = vim/bundle/indentobject
-	url = git://github.com/austintaylor/vim-indentobject.git
+	url = https://github.com/austintaylor/vim-indentobject.git
 [submodule "vim/bundle/rails"]
 	path = vim/bundle/rails
-	url = git://github.com/tpope/vim-rails.git
+	url = https://github.com/tpope/vim-rails.git
 [submodule "vim/bundle/repeat"]
 	path = vim/bundle/repeat
-	url = git://github.com/tpope/vim-repeat.git
+	url = https://github.com/tpope/vim-repeat.git
 [submodule "vim/bundle/ruby"]
 	path = vim/bundle/ruby
-	url = git://github.com/vim-ruby/vim-ruby.git
+	url = https://github.com/vim-ruby/vim-ruby.git
 [submodule "vim/bundle/surround"]
 	path = vim/bundle/surround
-	url = git://github.com/tpope/vim-surround.git
+	url = https://github.com/tpope/vim-surround.git
 [submodule "vim/bundle/unimpaired"]
 	path = vim/bundle/unimpaired
-	url = git://github.com/tpope/vim-unimpaired.git
+	url = https://github.com/tpope/vim-unimpaired.git
 [submodule "vim/bundle/bundler"]
 	path = vim/bundle/bundler
-	url = git://github.com/tpope/vim-bundler.git
+	url = https://github.com/tpope/vim-bundler.git
 [submodule "vim/bundle/vividchalk"]
 	path = vim/bundle/vividchalk
-	url = git://github.com/tpope/vim-vividchalk.git
+	url = https://github.com/tpope/vim-vividchalk.git
 [submodule "vim/bundle/greplace"]
 	path = vim/bundle/greplace
-	url = git://github.com/vim-scripts/greplace.vim.git
+	url = https://github.com/vim-scripts/greplace.vim.git
 [submodule "vim/bundle/pastie"]
 	path = vim/bundle/pastie
-	url = git://github.com/tpope/vim-pastie.git
+	url = https://github.com/tpope/vim-pastie.git
 [submodule "vim/bundle/snipmate"]
 	path = vim/bundle/snipmate
-	url = git://github.com/msanders/snipmate.vim
+	url = https://github.com/msanders/snipmate.vim
 [submodule "vim/bundle/solarized"]
 	path = vim/bundle/solarized
-	url = git://github.com/altercation/vim-colors-solarized.git
+	url = https://github.com/altercation/vim-colors-solarized.git
 [submodule "vim/bundle/javascript"]
 	path = vim/bundle/javascript
-	url = git://github.com/pangloss/vim-javascript.git
+	url = https://github.com/pangloss/vim-javascript.git
 [submodule "vim/bundle/ragtag"]
 	path = vim/bundle/ragtag
-	url = git://github.com/tpope/vim-ragtag.git
+	url = https://github.com/tpope/vim-ragtag.git
 [submodule "vim/bundle/commentary"]
 	path = vim/bundle/commentary
-	url = git://github.com/tpope/vim-commentary
+	url = https://github.com/tpope/vim-commentary
 [submodule "vim/bundle/handlebars"]
 	path = vim/bundle/handlebars
-	url = git://github.com/nono/vim-handlebars.git
+	url = https://github.com/nono/vim-handlebars.git
 [submodule "vim/bundle/tagbar"]
 	path = vim/bundle/tagbar
-	url = git://github.com/majutsushi/tagbar.git
+	url = https://github.com/majutsushi/tagbar.git
 [submodule "vim/bundle/vim-coffee-script"]
 	path = vim/bundle/vim-coffee-script
-	url = git://github.com/kchmck/vim-coffee-script.git
+	url = https://github.com/kchmck/vim-coffee-script.git
 [submodule "vim/bundle/jshint"]
 	path = vim/bundle/jshint
-	url = git://github.com/rmanalan/jshint.vim.git
+	url = https://github.com/rmanalan/jshint.vim.git
 [submodule "vim/bundle/protobuf"]
 	path = vim/bundle/protobuf
-	url = git://github.com/uarun/vim-protobuf.git
+	url = https://github.com/uarun/vim-protobuf.git
 [submodule "vim/bundle/gitgutter"]
 	path = vim/bundle/gitgutter
-	url = git://github.com/airblade/vim-gitgutter.git
+	url = https://github.com/airblade/vim-gitgutter.git
 [submodule "vim/bundle/vim-slim"]
 	path = vim/bundle/vim-slim
-	url = git://github.com/slim-template/vim-slim.git
+	url = https://github.com/slim-template/vim-slim.git
 [submodule "vim/bundle/typescript-vim"]
 	path = vim/bundle/typescript-vim
 	url = https://github.com/leafgarland/typescript-vim.git


### PR DESCRIPTION
Besides consistency,  the 'git://' protocol is sometimes blocked on certain public wifi networks. 'https://' tends to bypass this.
