### PR TITLE
Add shortcuts for faster access to vim commands.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -23,6 +23,7 @@ set laststatus=2                                             " always show statu
 set list                                                     " show trailing whitespace
 set listchars=tab:▸\ ,trail:▫
 set number                                                   " show line numbers
+set pastetoggle=<F2>                                         " when in insert mode, press <F2> to go to paste mode
 set ruler                                                    " show where you are
 set scrolloff=3                                              " show context above/below cursorline
 set shiftwidth=2                                             " normal mode indentation commands use 2 spaces
@@ -47,7 +48,7 @@ map <C-j> <C-w>j
 map <C-k> <C-w>k
 map <C-l> <C-w>l
 map <leader>l :Align
-nmap <leader>a :Ack 
+nmap <leader>a :Ack
 nmap <leader>b :CtrlPBuffer<CR>
 nmap <leader>d :NERDTreeToggle<CR>
 nmap <leader>f :NERDTreeFind<CR>
@@ -58,6 +59,8 @@ nmap <leader><space> :call whitespace#strip_trailing()<CR>
 nmap <leader>g :GitGutterToggle<CR>
 nmap <leader>c <Plug>Kwbd
 map <silent> <leader>V :source ~/.vimrc<CR>:filetype detect<CR>:exe ":echo 'vimrc reloaded'"<CR>
+
+nnoremap ; :                                                 " map ; to : for faster access to commands
 
 " plugin settings
 let g:ctrlp_match_window = 'order:ttb,max:20'


### PR DESCRIPTION
remap the semi-colon (:) to semi-colon (;) for faster access to vim commands.
map <F2> to pastetoggle to allow pasting of content without auto-indenting.
