### PR TITLE
prevent :filetype off from causing bad exit status

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,4 +1,5 @@
 " set up pathogen, https://github.com/tpope/vim-pathogen
+filetype on " without this vim emits a zero exit status, later, because of :ft off
 filetype off
 call pathogen#infect()
 filetype plugin indent on


### PR DESCRIPTION
Fixes https://github.com/square/maximum-awesome/issues/42 as discussed in the issue.
