### PR TITLE
Use copy-pipe for sending selections around.

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -46,8 +46,13 @@ bind-key T previous-window
 bind-key [ copy-mode
 bind-key ] paste-buffer
 
-# Clunkily connect tmux buffers with the pasteboard.
-bind-key y run "tmux save-buffer - | reattach-to-user-namespace pbcopy"
+# Setup 'v' to begin selection as in Vim
+bind-key -t vi-copy v begin-selection
+bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
+
+# Update default binding of `Enter` to also use copy-pipe
+unbind -t vi-copy Enter
+bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
 
 set-window-option display-panes-time 1500
 


### PR DESCRIPTION
@rudle @strongriley @steckel @cHoco

Stolen from http://robots.thoughtbot.com/post/55885045171/tmux-copy-paste-on-os-x-a-better-future.

Closes #47.
