### PR TITLE
,a includes comment in command

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -55,7 +55,7 @@ map <C-j> <C-w>j
 map <C-k> <C-w>k
 map <C-l> <C-w>l
 map <leader>l :Align
-nmap <leader>a :Ack "Adding comment to save the whitespace
+nmap <leader>a :Ack<space>
 nmap <leader>b :CtrlPBuffer<CR>
 nmap <leader>d :NERDTreeToggle<CR>
 nmap <leader>f :NERDTreeFind<CR>


### PR DESCRIPTION
See bottom: doing `,a` includes the comment in the command.
![screen shot 2013-09-09 at 9 15 47 pm](https://f.cloud.github.com/assets/313228/1112131/cc46f182-19cf-11e3-83fd-cd3b43d30b39.png)
