### PR TITLE
Mapping the space key instead of adding a comment.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -55,7 +55,7 @@ map <C-j> <C-w>j
 map <C-k> <C-w>k
 map <C-l> <C-w>l
 map <leader>l :Align
-nmap <leader>a :Ack "Adding comment to save the whitespace
+nmap <leader>a :Ack<Space>
 nmap <leader>b :CtrlPBuffer<CR>
 nmap <leader>d :NERDTreeToggle<CR>
 nmap <leader>f :NERDTreeFind<CR>


### PR DESCRIPTION
Why not simply add the space key mapping?
