### PR TITLE
Remove git submodules step

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -155,9 +155,6 @@ task :default do
   Rake::Task['install:tmux'].invoke
   Rake::Task['install:macvim'].invoke
 
-  step 'git submodules'
-  sh 'git submodule update --init'
-
   # TODO install gem ctags?
   # TODO run gem ctags?
 


### PR DESCRIPTION
As #56 merged, there seems no need to do `git submodules` step in `Rakefile`.
