### PR TITLE
Homebrew vim

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,6 +73,11 @@ namespace :install do
     unless system('which brew > /dev/null || ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"')
       raise "Homebrew must be installed before continuing."
     end
+    `brew doctor`
+    unless $?.success?
+      raise "The brew doctor says that your system is not ready to brew.\n"+
+            "Please fix the errors."
+    end
   end
 
   desc 'Install The Silver Searcher'


### PR DESCRIPTION
The default Mountain Lion version of vim has the clipboard integration disabled. This adds a task to install the homebrew version of vim as the default vi so that works.

There is a second commit that hides the standard error of the 'brew list' command, because that will generate an odd "no such keg" message.
