### PR TITLE
moving set number to vimrc.local

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -32,7 +32,6 @@ set incsearch                                                " search as you typ
 set laststatus=2                                             " always show statusline
 set list                                                     " show trailing whitespace
 set listchars=tab:▸\ ,trail:▫
-set number                                                   " show line numbers
 set ruler                                                    " show where you are
 set scrolloff=3                                              " show context above/below cursorline
 set shiftwidth=2                                             " normal mode indentation commands use 2 spaces

--- a/vimrc.local
+++ b/vimrc.local
@@ -1,4 +1,5 @@
 set nocursorline " don't highlight current line
+set number                                                   " show line numbers
 
 " keyboard shortcuts
 inoremap jj <ESC>


### PR DESCRIPTION
You cannot have both `set number` and `set relativenumber` together in the same configuration.  This simply moves `set number` to vimrc.local so that the setting can be changed to `set relativenumber` for those users who want it.
