### PR TITLE
Fix the slowness experienced with ,a & ,t.

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -11,3 +11,19 @@ if (&t_Co == 256 || has('gui_running'))
     colorscheme desert
   endif
 endif
+
+" Disambiguate ,a & ,t from the Align plugin, making them fast again.
+"
+" This section is here to prevent AlignMaps from adding a bunch of mappings
+" that interfere with the very-common ,a and ,t mappings. This will get run
+" at every startup to remove the AlignMaps for the *next* vim startup.
+"
+" If you do want the AlignMaps mappings, remove this section, remove
+" ~/.vim/bundle/Align, and re-run rake in maximum-awesome.
+function! s:RemoveConflictingAlignMaps()
+  if exists("g:loaded_AlignMapsPlugin")
+    AlignMapsClean
+  endif
+endfunction
+command! -nargs=0 RemoveConflictingAlignMaps call s:RemoveConflictingAlignMaps()
+silent! autocmd VimEnter * RemoveConflictingAlignMaps


### PR DESCRIPTION
@matthewtodd @rudle @strongriley 

tl;dr: this speeds up `,a` and `,t` by removing conflicting mappings.

The Align plugin comes with AlignMaps which adds a bunch of mappings for special kinds of alignments. I never use these and I don't know if anyone else does. This wouldn't be a problem except that many of them begin with `,a` or `,t`, which forces vim to wait to make sure you really meant `,a` and `,t` when you type them before running the associated command. This makes those commands appear to be slow. My solution is to run `AlignMapsClean` if the plugin has been loaded when vim starts up. This has the effect of removing the AlignMaps plugin from the Align plugin so that the _next_ time you start vim the commands will be fast. First-time users would see slowness with `,a` and `,t` the first time they launch vim using maximum-awesome.
