### PR TITLE
Fix vim/tmux pane switching

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -30,6 +30,13 @@ bind-key j select-pane -D
 bind-key k select-pane -U
 bind-key l select-pane -R
 
+# smart pane switching with awareness of vim splits
+bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-h) || tmux select-pane -L"
+bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-j) || tmux select-pane -D"
+bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-k) || tmux select-pane -U"
+bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-l) || tmux select-pane -R"
+bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys 'C-\\') || tmux select-pane -l"
+
 bind-key C-o rotate-window
 
 bind-key + select-layout main-horizontal


### PR DESCRIPTION
I recently realised that the uniform tmux/vim pane switching isn't working as expected.
More specifically, I was unable to switch between vim and tmux panes with same set of keys (i.e. c-h/j/k/l). 

After checking the tmux configuration required in the [christoomey/vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) bundle and adding it to my tmux.conf, this issue was solved.
