### PR TITLE
Run the vim we installed when setting up Vundle.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -158,7 +158,7 @@ exec /Applications/MacVim.app/Contents/MacOS/Vim "$@"
   task :vundle do
     step 'vundle'
     install_github_bundle 'gmarik','vundle'
-    sh 'vim -c "BundleInstall" -c "q" -c "q"'
+    sh '~/bin/vim -c "BundleInstall" -c "q" -c "q"'
   end
 end
 


### PR DESCRIPTION
@rudle 

This should allow us to at least complete the first run for someone who doesn't have ~/bin in their PATH. Closes #119.
