### PR TITLE
Fix typo for local bundles filename.

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -1,7 +1,7 @@
 " Bundles here are part of the core Maximum Awesome setup
 " Do NOT add bundles to this list, as they might get removed when you upgrade
 " Maximum Awesome.
-" Please create ~/.vim.bundles.local and add any extra bundles you want there
+" Please create ~/.vimrc.bundles.local and add any extra bundles you want there
 Bundle 'airblade/vim-gitgutter'
 Bundle 'altercation/vim-colors-solarized'
 Bundle 'austintaylor/vim-indentobject'


### PR DESCRIPTION
Fixes a typo in vimrc.bundles which referenced ~/.vim.bundles.local instead of ~/.vimrc.bundles.local
