### PR TITLE
added -g to display-panes-time

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -65,7 +65,7 @@ bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
 unbind -t vi-copy Enter
 bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
 
-set-window-option display-panes-time 1500
+set-window-option -g display-panes-time 1500
 
 # Status Bar
 set-option -g status-interval 1


### PR DESCRIPTION
fixes tmux complaint `/Users/<name>/.tmux.conf:68: couldn't set 'display-panes-time' need target session or -g`
