### PR TITLE
install tmux version >= 1.8

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,20 @@
 ENV['HOMEBREW_CASK_OPTS'] = "--appdir=/Applications"
 
 def brew_install(package, *options)
-  brew_tmux_query = `brew list #{package}`
+  brew_tmux_query = `brew list #{package} --versions`
 
   # if brew exits with error we install tmux
   unless $?.success?
     sh "brew install #{package} #{options.join ' '}"
   else
     # brew did not error out, verify tmux is greater than 1.8
-    # e.g. /usr/local/Cellar/tmux/1.9a/bin/tmux
+    # e.g. brew_tmux_query = 'tmux 1.9a'
     # tmux copy-pipe function needs tmux >= 1.8
-    tmux_version = brew_tmux_query.split(/\n/).first.split('/')[5].to_f
+    tmux_installed_version = brew_tmux_query.split(/\n/).first.split(' ')[1]
+    tmux_installed_version = Gem::Version.new(tmux_installed_version)
+    tmux_1_8 = Gem::Version.new('1.8')
 
-    unless tmux_version >= 1.8
+    unless tmux_installed_version >= tmux_1_8
       sh "brew upgrade #{package} #{options.join ' '}"
     end
   end


### PR DESCRIPTION
the copy functions for tmux on mac osx depend on the `copy-pipe` function to be available. That function was implemented in tmux version 1.8. This code ensures that tmux version >= 1.8 is installed. The previous code only checked if any tmux version was installed.
