### PR TITLE
new splits are open to the current directory

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -26,8 +26,8 @@ bind-key bspace previous-window
 bind-key enter next-layout
 
 # use vim-like keys for splits and windows
-bind-key v split-window -h
-bind-key s split-window -v
+bind-key v split-window -h -c "#{pane_current_path}"
+bind-key s split-window -v -c "#{pane_current_path}"
 bind-key h select-pane -L
 bind-key j select-pane -D
 bind-key k select-pane -U


### PR DESCRIPTION
If you split the current window, the new pane will start off in the same directory.
If you make a new window it will start off from whatever directory tmux was launched in, that behavior isn't affected. This makes it easier for me to setup a workspace in a particular directory.