### PR TITLE
Fixes unspecified register yanking in TMUX

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -80,10 +80,12 @@ autocmd User Rails silent! Rnavcommand stepdefinition features/step_definitions 
 " automatically rebalance windows on vim resize
 autocmd VimResized * :wincmd =
 
-" Fix Cursor in TMUX
 if exists('$TMUX')
+  " Fix Cursor
   let &t_SI = "\<Esc>Ptmux;\<Esc>\<Esc>]50;CursorShape=1\x7\<Esc>\\"
   let &t_EI = "\<Esc>Ptmux;\<Esc>\<Esc>]50;CursorShape=0\x7\<Esc>\\"
+  " Fix unnamed register yanking
+  set clipboard-=unnamed
 else
   let &t_SI = "\<Esc>]50;CursorShape=1\x7"
   let &t_EI = "\<Esc>]50;CursorShape=0\x7"


### PR DESCRIPTION
Fixes an issue with Vim inside TMUX where yanking then pasting, e.g. `yyp`, was giving an empty register error. C.f. http://stackoverflow.com/questions/11404800/fix-vim-tmux-yank-paste-on-unnamed-register