### PR TITLE
add binding for virtual line navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ peace-loving hippies. Built for Mac OS X.
 * `<C-]>` jump to definition using ctags
 * `,l` begins aligning lines on a string, usually used as `,l=` to align assignments
 * `<C-hjkl>` move between windows, shorthand for `<C-w> hjkl`
+* <kbd>up arrow</kbd> and <kbd>down arrow</kbd> will move up and down _virtual_ lines if `:set wrap` is on.
 
 ### tmux
 

--- a/vimrc
+++ b/vimrc
@@ -69,6 +69,14 @@ nnoremap <leader>g :GitGutterToggle<CR>
 nnoremap <leader>c <Plug>Kwbd
 noremap <silent> <leader>V :source ~/.vimrc<CR>:filetype detect<CR>:exe ":echo 'vimrc reloaded'"<CR>
 
+" When using :set wrap, the arrow keys will go up/down a visual line where as
+" j/k will go down/up _real_ lines
+nnoremap <Down> gj
+nnoremap <Up> gk
+vnoremap <Down> gj
+vnoremap <Up> gk
+inoremap <Down> <C-o>gj
+inoremap <Up> <C-o>gk
 " in case you forgot to sudo
 cnoremap w!! %!sudo tee > /dev/null %
 


### PR DESCRIPTION
When using vim for non-coding tasks (email, etc) you want to `:set wrap` because that is how people generally format email in office communications.  This makes using traditional vim navigation keys difficult.  I set up these bindings to navigate virtual lines a little more easily