### PR TITLE
update homebrew installer url to https://raw.githubusercontent.com/Homebrew/install/master/install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -119,7 +119,7 @@ namespace :install do
   desc 'Update or Install Brew'
   task :brew do
     step 'Homebrew'
-    unless system('which brew > /dev/null || ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"')
+    unless system('which brew > /dev/null || ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"')
       raise "Homebrew must be installed before continuing."
     end
   end


### PR DESCRIPTION
Update homebrew installer url from `https://raw.github.com/Homebrew/homebrew/go/install` to `https://raw.githubusercontent.com/Homebrew/install/master/install`.

I got the following output at around 4:30am GMT on Oct 08, 2014 after trying to install maximum-awesome on a machine without homebrew.

```
$ rake

-- Homebrew --------------------------------------------------------------------
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!

-- Homebrew Cask ---------------------------------------------------------------
sh: brew: command not found
sh: brew: command not found
Failed to tap caskroom/homebrew-cask in Homebrew.
```
