### PR TITLE
fixes tmux version checking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,15 +11,23 @@ def brew_install(package, *args)
     # brew did not error out, verify tmux is greater than 1.8
     # e.g. brew_tmux_query = 'tmux 1.9a'
     installed_version = versions.split(/\n/).first.split(' ')[1]
-    unless version_match?(options[:version], installed_version)
+    unless version_match?(options[:requires], installed_version)
       sh "brew upgrade #{package} #{args.join ' '}"
     end
   end
 end
 
-def version_match?(requirement, version)
+def version_match?(requirement, v)
   # This is a hack, but it lets us avoid a gem dep for version checking.
+  version = parse_version(v)
   Gem::Dependency.new('', requirement).match?('', version)
+end
+
+def parse_version(version)
+  a = /(\d+\.\d+)/.match version
+  if a
+    a[1]
+  end
 end
 
 def install_github_bundle(user, package)


### PR DESCRIPTION
- options[:version] was nil, options[:requires] has the requirement
- my installed tmux version, 1.9a, failed the version match, but 1.9 passes.
  changes version_match? to only check digits