### PR TITLE
Update Vundle path

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -7,7 +7,7 @@ syntax enable
 " configure Vundle
 filetype on " without this vim emits a zero exit status, later, because of :ft off
 filetype off
-set rtp+=~/.vim/bundle/vundle.vim/
+set rtp+=~/.vim/bundle/vundle/
 call vundle#begin()
 
 " install Vundle bundles


### PR DESCRIPTION
Vundle gets installed to ~/.vim/bundle/vundle/, not ~/.vim/bundle/vundle.vim/, which the current .vimrc specifies. This makes vim barf when opening and fail to load any plugins.

Here's the output I get on a completely clean install of maximum-awesome (no pre-existing vim configs, no tmux - which causes an error if it's already installed, but that's for another issue).

```
% git clone git@github.com:square/maximum-awesome.git
Cloning into 'maximum-awesome'...
remote: Counting objects: 753, done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 753 (delta 2), reused 0 (delta 0), pack-reused 746
Receiving objects: 100% (753/753), 370.42 KiB | 0 bytes/s, done.
Resolving deltas: 100% (325/325), done.
Checking connectivity... done.
% cd maximum-awesome
% ls
LICENSE                 iterm2-colors-solarized vim                     vimrc.bundles.local
README.md               tmux.conf               vimrc                   vimrc.local
Rakefile                tmux.conf.local         vimrc.bundles
% brew uninstall tmux
Uninstalling /usr/local/Cellar/tmux/1.9a... (16 files, 640K)
% rake

-- Homebrew --------------------------------------------------------------------

-- Homebrew Cask ---------------------------------------------------------------

-- the_silver_searcher ---------------------------------------------------------

-- iterm2 ----------------------------------------------------------------------

-- ctags -----------------------------------------------------------------------

-- reattach-to-user-namespace --------------------------------------------------

-- tmux ------------------------------------------------------------------------
brew install tmux 
==> Downloading https://homebrew.bintray.com/bottles/tmux-1.9a.yosemite.bottle.1.tar.gz
Already downloaded: /Library/Caches/Homebrew/tmux-1.9a.yosemite.bottle.1.tar.gz
==> Pouring tmux-1.9a.yosemite.bottle.1.tar.gz
==> Caveats
Example configurations have been installed to:
  /usr/local/Cellar/tmux/1.9a/share/tmux/examples

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/tmux/1.9a: 16 files, 640K

-- MacVim ----------------------------------------------------------------------
Please add ~/bin to your PATH, e.g. run this command:

  echo 'export PATH="~/bin:$PATH"' >> ~/.bashrc

The exact command and file will vary by your shell and configuration.

-- symlink ---------------------------------------------------------------------
ln -s /Users/pink/Development/maximum-awesome/vim /Users/pink/.vim
ln -s /Users/pink/Development/maximum-awesome/vimrc /Users/pink/.vimrc
ln -s /Users/pink/Development/maximum-awesome/vimrc.bundles /Users/pink/.vimrc.bundles
cp /Users/pink/Development/maximum-awesome/vimrc.local /Users/pink/.vimrc.local
cp /Users/pink/Development/maximum-awesome/vimrc.bundles.local /Users/pink/.vimrc.bundles.local

-- vundle ----------------------------------------------------------------------
git clone https://github.com/gmarik/vundle ~/.vim/bundle/vundle
Cloning into '/Users/pink/.vim/bundle/vundle'...
remote: Counting objects: 2903, done.
remote: Total 2903 (delta 0), reused 0 (delta 0), pack-reused 2903
Receiving objects: 100% (2903/2903), 858.69 KiB | 0 bytes/s, done.
Resolving deltas: 100% (997/997), done.
Checking connectivity... done.
~/bin/vim -c "PluginInstall!" -c "q" -c "q"
Error detected while processing /Users/pink/.vimrc:
line   11:
E117: Unknown function: vundle#begin
Error detected while processing /Users/pink/.vimrc.bundles:
line    5:
E492: Not an editor command: Plugin 'gmarik/vundle.vim'
line    6:
E492: Not an editor command: Plugin 'airblade/vim-gitgutter'
line    7:
E492: Not an editor command: Plugin 'altercation/vim-colors-solarized'
line    8:
E492: Not an editor command: Plugin 'austintaylor/vim-indentobject'
line    9:
E492: Not an editor command: Plugin 'christoomey/vim-tmux-navigator'
line   10:
E492: Not an editor command: Plugin 'juvenn/mustache.vim'
line   11:
E492: Not an editor command: Plugin 'kchmck/vim-coffee-script'
line   12:
E492: Not an editor command: Plugin 'kien/ctrlp.vim'
line   13:
E492: Not an editor command: Plugin 'leafgarland/typescript-vim'
line   14:
E492: Not an editor command: Plugin 'majutsushi/tagbar'
line   15:
E492: Not an editor command: Plugin 'rking/ag.vim'
line   16:
E492: Not an editor command: Plugin 'garbas/vim-snipmate'
line   17:
E492: Not an editor command: Plugin 'MarcWeber/vim-addon-mw-utils'
line   18:
E492: Not an editor command: Plugin 'tomtom/tlib_vim'
line   19:
E492: Not an editor command: Plugin 'nathanaelkane/vim-indent-guides'
line   20:
E492: Not an editor command: Plugin 'nono/vim-handlebars'
line   21:
E492: Not an editor command: Plugin 'pangloss/vim-javascript'
line   22:
E492: Not an editor command: Plugin 'wookiehangover/jshint.vim'
line   23:
E492: Not an editor command: Plugin 'scrooloose/nerdtree'
line   24:
E492: Not an editor command: Plugin 'scrooloose/syntastic'
line   25:
E492: Not an editor command: Plugin 'slim-template/vim-slim'
line   26:
E492: Not an editor command: Plugin 'tpope/vim-bundler'
line   27:
E492: Not an editor command: Plugin 'tpope/vim-commentary'
line   28:
E492: Not an editor command: Plugin 'tpope/vim-cucumber'
line   29:
E492: Not an editor command: Plugin 'tpope/vim-dispatch'
line   30:
E492: Not an editor command: Plugin 'tpope/vim-endwise'
line   31:
E492: Not an editor command: Plugin 'tpope/vim-fugitive'
line   32:
E492: Not an editor command: Plugin 'tpope/vim-pastie'
line   33:
E492: Not an editor command: Plugin 'tpope/vim-ragtag'
line   34:
E492: Not an editor command: Plugin 'tpope/vim-rails'
line   35:
E492: Not an editor command: Plugin 'tpope/vim-repeat'
line   36:
E492: Not an editor command: Plugin 'tpope/vim-surround'
line   37:
E492: Not an editor command: Plugin 'tpope/vim-unimpaired'
line   38:
E492: Not an editor command: Plugin 'tpope/vim-vividchalk'
line   39:
E492: Not an editor command: Plugin 'eventualbuddha/vim-protobuf'
line   40:
E492: Not an editor command: Plugin 'vim-ruby/vim-ruby'
line   41:
E492: Not an editor command: Plugin 'vim-scripts/Align'
line   42:
E492: Not an editor command: Plugin 'vim-scripts/greplace.vim'
line   43:
E492: Not an editor command: Plugin 'vim-scripts/matchit.zip'
Error detected while processing /Users/pink/.vimrc:
line   19:
E117: Unknown function: vundle#end
Press ENTER or type command to continue

-- iterm2 colorschemes ---------------------------------------------------------

-- iterm2 profiles -------------------------------------------------------------

  Your turn!

  Go and manually set up Solarized Light and Dark profiles in iTerm2.
  (You can do this in 'Preferences' -> 'Profiles' by adding a new profile,
  then clicking the 'Colors' tab, 'Load Presets...' and choosing a Solarized option.)
  Also be sure to set Terminal Type to 'xterm-256color' in the 'Terminal' tab.

  Enjoy!
```

You can test that this fix works (at least on Yosemite) by repeating the install process with my branch: `git clone git@github.com:Pinkerton/maximum-awesome.git`.