### PR TITLE
Continue if tmux already installed.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ def brew_install(package, *args)
     # e.g. brew_tmux_query = 'tmux 1.9a'
     installed_version = versions.split(/\n/).first.split(' ')[1]
     unless version_match?(options[:version], installed_version)
-      sh "brew upgrade #{package} #{args.join ' '}"
+      sh "brew upgrade #{package} #{args.join ' '}" rescue nil
     end
   end
 end


### PR DESCRIPTION
Running `rake` on master with rake v10.4.2 failed with error:

```
Error: tmux 2.0 already installed
rake aborted!
```

With the change, it will still print the error message, but will not abort the process.