### PR TITLE
Updated: replace old options for mouse behavior with new options

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -11,9 +11,8 @@ bind-key R source-file ~/.tmux.conf \; display-message "tmux.conf reloaded."
 setw -g mode-keys vi
 
 # mouse behavior
-setw -g mode-mouse on
-set -g mouse-select-pane on
-set -g mouse-resize-pane on
+set -g mouse-utf8 on
+set -g mouse on
 
 set-option -g default-terminal screen-256color
 


### PR DESCRIPTION
As discussed in [this question](http://stackoverflow.com/questions/30185210/ubuntu-change-tmux-1-8-to-tmux-next-1-9) on StackOverflow:

> Options `mode-mouse`, `mouse-select-pane`, `mouse-resize-pane`, `mouse-select-window` seem to be deprecated. Use `mouse` option instead, it covers all the functionality of those four options

I think may be this should updated in Maximum-awesome as well, otherwise people using new version of tmux will have to update themselves.