### PR TITLE
Update tmux.conf for tmux 2.1

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -11,9 +11,7 @@ bind-key R source-file ~/.tmux.conf \; display-message "tmux.conf reloaded."
 setw -g mode-keys vi
 
 # mouse behavior
-setw -g mode-mouse on
-set -g mouse-select-pane on
-set -g mouse-resize-pane on
+set -g mouse on
 
 set-option -g default-terminal screen-256color
 


### PR DESCRIPTION
```
 Mouse-mode has been rewritten.  There's now no longer options for:
    - mouse-resize-pane
    - mouse-select-pane
    - mouse-select-window
    - mode-mouse

  Instead there is just one option:  'mouse' which turns on mouse support
```