### PR TITLE
Pass the correct binary directory to brew-cask.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ def brew_cask_install(package, *options)
   output = `brew cask info #{package}`
   return unless output.include?('Not installed')
 
-  sh "brew cask install #{package} #{options.join ' '}"
+  sh "brew cask install --binarydir=#{`brew --prefix`.chomp}/bin #{package} #{options.join ' '}"
 end
 
 def step(description)


### PR DESCRIPTION
This makes installation work when homebrew is in a location other than /usr/local.