### PR TITLE
Fix to enable iTerm2 "Send Hex Codes" to work with tmux 2.1

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -97,4 +97,9 @@ set-option -g repeat-time 0
 bind-key -T root WheelUpPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; copy-mode -e; send-keys -M"
 bind-key -T root WheelDownPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; send-keys -M"
 
+# Disable assume-paste-time, so that iTerm2's "Send Hex Codes" feature works
+# with tmux 2.1. This is backwards-compatible with earlier versions of tmux,
+# AFAICT.
+set-option -g assume-paste-time 0
+
 source-file ~/.tmux.conf.local


### PR DESCRIPTION
tmux 2.1 changed s.t. the default value of the `assume-paste-time` session option (1) breaks iTerm2's "Send Hex Codes". This PR disables the session option, so tmux properly interprets the hex codes as tmux key bindings.