### PR TITLE
Re-enable scrolling with the mousewheel/trackpad in tmux 2.1

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -93,4 +93,8 @@ set-option -g default-command "/bin/bash -c 'which reattach-to-user-namespace >/
 # Allow the arrow key to be used immediately after changing windows
 set-option -g repeat-time 0
 
+# Fix to allow mousewheel/trackpad scrolling in tmux 2.1
+bind-key -T root WheelUpPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; copy-mode -e; send-keys -M"
+bind-key -T root WheelDownPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; send-keys -M"
+
 source-file ~/.tmux.conf.local


### PR DESCRIPTION
Something changed in tmux 2.1 to break mousewheel/trackpad scrolling. This fixes it.

(See https://gitlab.com/gnachman/iterm2/issues/3950.)