### PR TITLE
Removing mouse-utf8 option from tmux config as per removal in tmux 2.2

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -11,7 +11,6 @@ bind-key R source-file ~/.tmux.conf \; display-message "tmux.conf reloaded."
 setw -g mode-keys vi
 
 # mouse behavior
-set -g mouse-utf8 on
 set -g mouse on
 
 set-option -g default-terminal screen-256color


### PR DESCRIPTION
See issue #216. Consider re-opening issue now that tmux 2.2 has been updated in brew, and utf-8 is now supported by default (see changelog [here](https://raw.githubusercontent.com/tmux/tmux/master/CHANGES))