### PR TITLE
Removes brew-cask install step, as it is deprecated

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,17 +126,6 @@ namespace :install do
     end
   end
 
-  desc 'Install Homebrew Cask'
-  task :brew_cask do
-    step 'Homebrew Cask'
-    system('brew untap phinze/cask') if system('brew tap | grep phinze/cask > /dev/null')
-    unless system('brew tap | grep caskroom/cask > /dev/null') || system('brew tap caskroom/homebrew-cask')
-      abort "Failed to tap caskroom/homebrew-cask in Homebrew."
-    end
-
-    brew_install 'brew-cask'
-  end
-
   desc 'Install The Silver Searcher'
   task :the_silver_searcher do
     step 'the_silver_searcher'
@@ -230,7 +219,6 @@ LINKED_FILES = filemap(
 desc 'Install these config files.'
 task :install do
   Rake::Task['install:brew'].invoke
-  Rake::Task['install:brew_cask'].invoke
   Rake::Task['install:the_silver_searcher'].invoke
   Rake::Task['install:iterm'].invoke
   Rake::Task['install:ctags'].invoke


### PR DESCRIPTION
This change fixes the maximum-awesome installation failure due to being unable to install Homebrew-cask (error message 'No available formula with the name 'brew-cask"').

As of December 2015, "brew install brew-cask" is deprecated in favor of keeping Homebrew-cask up-to-date together with Homebrew.  For details, see:

https://github.com/ctran/homebrew-cask#important-december-2015-update-homebrew-cask-will-now-be-kept-up-to-date-together-with-homebrew-see-15381-for-details-if-you-havent-yet-run-brew-uninstall---force-brew-cask-brew-update-to-switch-to-the-new-system

TESTED=Confirmed that maximum-awesome install process works as expected with the proposed changes.