### PR TITLE
"brew cask" is no longer installable via `brew install`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,11 +130,9 @@ namespace :install do
   task :brew_cask do
     step 'Homebrew Cask'
     system('brew untap phinze/cask') if system('brew tap | grep phinze/cask > /dev/null')
-    unless system('brew tap | grep caskroom/cask > /dev/null') || system('brew tap caskroom/homebrew-cask')
-      abort "Failed to tap caskroom/homebrew-cask in Homebrew."
+    unless system('brew tap | grep caskroom/cask > /dev/null') || system('brew tap caskroom/cask')
+      abort "Failed to tap caskroom/cask in Homebrew."
     end
-
-    brew_install 'brew-cask'
   end
 
   desc 'Install The Silver Searcher'


### PR DESCRIPTION
We remove this line to allow installation to proceed. It is imperative that brew
cask be tapped, per[1] brew tap caskroom/cask will install brew-cask as a
Homebrew external command, and brew update will keep it up-to-date.

[1] https://github.com/caskroom/homebrew-cask/releases/tag/v0.60.0

Fixes #225 #228 
Supercedes #224 

@ggilder @mpuncel