### PR TITLE
More robust version checking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,9 @@ end
 def version_match?(requirement, version)
   # This is a hack, but it lets us avoid a gem dep for version checking.
   # Gem dependencies must be numeric, so we remove non-numeric characters here.
-  version.gsub!(/[a-zA-Z]/, '')
-  Gem::Dependency.new('', requirement).match?('', version)
+  matches = version.match(/(?<versionish>\d+\.\d+)/)
+  return false unless matches.length > 0
+  Gem::Dependency.new('', requirement).match?('', matches.captures[0])
 end
 
 def install_github_bundle(user, package)


### PR DESCRIPTION
We only care about the major version, so we filter out extraneous information.

Fixes #230 

I'm not super happy with the ruby regexp API. Any tips to clean up this code would be welcomed.

@ggilder