### PR TITLE
Update tmux copy-mode keybindings

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -57,11 +57,11 @@ bind-key ] paste-buffer
 
 # Setup 'v' to begin selection as in Vim
 bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi y send-keys -X copy-pipe "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 # Update default binding of `Enter` to also use copy-pipe
 unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send-keys -X copy-pipe "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 set-window-option -g display-panes-time 1500
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -55,13 +55,22 @@ bind-key T previous-window
 bind-key [ copy-mode
 bind-key ] paste-buffer
 
-# Setup 'v' to begin selection as in Vim
-bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -c 6-)"
 
+# Setup 'v' to begin selection as in Vim
 # Update default binding of `Enter` to also use copy-pipe
-unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+#
+# New keybindings for vi-mode when version >= 2.4
+# https://github.com/tmux/tmux/issues/754
+if-shell -b '[ "$(echo "$TMUX_VERSION >= 2.4" | bc)" = 1 ]' \
+  'bind-key -T copy-mode-vi v send-keys -X begin-selection ; \
+  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy" ; \
+  unbind -T copy-mode-vi Enter ; \
+  bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"; ' \
+  'bind-key -t vi-copy v begin-selection ; \
+  bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy" ; \
+  unbind -t vi-copy Enter ; \
+  bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"; '
 
 set-window-option -g display-panes-time 1500
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -56,12 +56,12 @@ bind-key [ copy-mode
 bind-key ] paste-buffer
 
 # Setup 'v' to begin selection as in Vim
-bind-key -t vi-copy v begin-selection
-bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-pipe "reattach-to-user-namespace pbcopy"
 
 # Update default binding of `Enter` to also use copy-pipe
-unbind -t vi-copy Enter
-bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
+unbind -T copy-mode-vi Enter
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe "reattach-to-user-namespace pbcopy"
 
 set-window-option -g display-panes-time 1500
 


### PR DESCRIPTION
Fix tmux copy-mode keybindings for tmux 2.4.

Based on this issue: https://github.com/tmux/tmux/issues/754

@eventualbuddha 