### PR TITLE
binarydir is no longer a valid option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ def brew_cask_install(package, *options)
   output = `brew cask info #{package}`
   return unless output.include?('Not installed')
 
-  sh "brew cask install --binarydir=#{`brew --prefix`.chomp}/bin #{package} #{options.join ' '}"
+  sh "brew cask install #{package} #{options.join ' '}"
 end
 
 def step(description)


### PR DESCRIPTION
Installation seems to work fine if I just remove it.