### PR TITLE
Fix broken tmux configurations

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -78,18 +78,18 @@ set-window-option -g display-panes-time 1500
 set-option -g status-interval 1
 set-option -g status-left ''
 set-option -g status-right '%l:%M%p'
-set-window-option -g window-status-current-fg magenta
-set-option -g status-fg default
+set-window-option -g window-status-current-style fg=magenta
+set-option -g status-style fg=default
 
 # Status Bar solarized-dark (default)
-set-option -g status-bg black
-set-option -g pane-active-border-fg black
-set-option -g pane-border-fg black
+set-option -g status-style bg=black
+set-option -g pane-active-border-style fg=black
+set-option -g pane-border-style fg=black
 
 # Status Bar solarized-light
-if-shell "[ \"$COLORFGBG\" = \"11;15\" ]" "set-option -g status-bg white"
-if-shell "[ \"$COLORFGBG\" = \"11;15\" ]" "set-option -g pane-active-border-fg white"
-if-shell "[ \"$COLORFGBG\" = \"11;15\" ]" "set-option -g pane-border-fg white"
+if-shell "[ \"$COLORFGBG\" = \"11;15\" ]" "set-option -g status-style bg=white"
+if-shell "[ \"$COLORFGBG\" = \"11;15\" ]" "set-option -g pane-active-border-style fg=white"
+if-shell "[ \"$COLORFGBG\" = \"11;15\" ]" "set-option -g pane-border-style fg=white"
 
 # Set window notifications
 setw -g monitor-activity on


### PR DESCRIPTION
# Bug
When `tmux` opens, you are greeted by this error (or something similar depending if you have `solarized-light` instead of `solarized-dark`).

```
/Users/<username>/.tmux.conf:81: invalid option: window-status-current-fg
/Users/<username>/.tmux.conf:86: invalid option: pane-active-border-fg
/Users/<username>/.tmux.conf:87: invalid option: pane-border-fg
```

# Fix
The syntax for some tmux styling has changed from deprecated to removed as referenced by this GitHub issue.
https://github.com/tmux/tmux/issues/1689#issuecomment-486722349

Here's the FAQ on the style update.
https://github.com/tmux/tmux/wiki/FAQ#how-do-i-translate--fg--bg-and--attr-options-into--style-options

Here's the `man` page on the styles.
https://man.openbsd.org/tmux.1#STYLES