### PR TITLE
[Bugfix] No longer necessary to tap caskroom/cask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,15 +127,6 @@ namespace :install do
     end
   end
 
-  desc 'Install Homebrew Cask'
-  task :brew_cask do
-    step 'Homebrew Cask'
-    system('brew untap phinze/cask') if system('brew tap | grep phinze/cask > /dev/null')
-    unless system('brew tap | grep caskroom/cask > /dev/null') || system('brew tap caskroom/cask')
-      abort "Failed to tap caskroom/cask in Homebrew."
-    end
-  end
-
   desc 'Install The Silver Searcher'
   task :the_silver_searcher do
     step 'the_silver_searcher'
@@ -229,7 +220,6 @@ LINKED_FILES = filemap(
 desc 'Install these config files.'
 task :install do
   Rake::Task['install:brew'].invoke
-  Rake::Task['install:brew_cask'].invoke
   Rake::Task['install:the_silver_searcher'].invoke
   Rake::Task['install:iterm'].invoke
   Rake::Task['install:ctags'].invoke


### PR DESCRIPTION
It is no longer necessary to run:

    brew tap caskroom/cask

Attempting to run this will get the error:

    Error: caskroom/cask was moved. Tap homebrew/cask-cask instead.

This is now included with `brew` by default.

This also fixes issue #258, but differently from fix #259 because it appears that tapping cask is no longer necessary based on this comment [here](https://stackoverflow.com/questions/58335410/error-caskroom-cask-was-moved-tap-homebrew-cask-cask-instead).