### PR TITLE
Allow for `tmux` versions ending in "a"

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -59,18 +59,10 @@ run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -c 6-)"
 
 # Setup 'v' to begin selection as in Vim
 # Update default binding of `Enter` to also use copy-pipe
-#
-# New keybindings for vi-mode when version >= 2.4
-# https://github.com/tmux/tmux/issues/754
-if-shell -b '[ "$(echo "$TMUX_VERSION >= 2.4" | bc)" = 1 ]' \
-  'bind-key -T copy-mode-vi v send-keys -X begin-selection ; \
-  bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy" ; \
-  unbind -T copy-mode-vi Enter ; \
-  bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"; ' \
-  'bind-key -t vi-copy v begin-selection ; \
-  bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy" ; \
-  unbind -t vi-copy Enter ; \
-  bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"; '
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+unbind -T copy-mode-vi Enter
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 set-window-option -g display-panes-time 1500
 


### PR DESCRIPTION
If the tmux version ends in "a", as it does today with version 3.3a,
your `~/.tmux.conf` will break and you will be sad.

I'm removing the check for version 2.4 because it shipped a while ago
and allows me to remove the dependency on `bc`.

Here's where I figured this all out:
https://github.com/tmux/tmux/issues/3219#issuecomment-1151776848