### PR TITLE
fix: replace `File.exists?` with `File.exist?`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vim/.netrwhist
+.idea

--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ end
 def link_file(original_filename, symlink_filename)
   original_path = File.expand_path(original_filename)
   symlink_path = File.expand_path(symlink_filename)
-  if File.exists?(symlink_path) || File.symlink?(symlink_path)
+  if File.exist?(symlink_path) || File.symlink?(symlink_path)
     if File.symlink?(symlink_path)
       symlink_points_to_path = File.readlink(symlink_path)
       return if symlink_points_to_path == original_path


### PR DESCRIPTION
Ruby deprecated File.exists? in favor of File.exist? in Ruby 2.1, which was released on December 25, 2013. The method File.exists? was completely removed in Ruby 3.0, released on December 25, 2020.